### PR TITLE
Added support for serving .xml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All released versions are available as
 
 ## Release Notes
 
+`v0.1.6` **Added Support for Serving XML Files** (2020-08-05)
+
 `v0.1.5` **Added Support for Reading Extensionless HTML Files** (2020-07-07)
 
 `v0.1.4` **Added Support for Trailing Slashes to Load Subdirectories** (2020-05-24)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@
 
 Before contributing, please first discuss the change(s) you wish to make.  
 You may [create an issue](https://github.com/tforster/http2-server/issues/new)
-or [contact the owner](https://github.com/webdivelement) of this repository.
+or [contact the owner](https://github.com/tforster) of this repository.
 
 ## Code of Conduct
 
@@ -75,7 +75,7 @@ of the repository with your account.
     - Additional noteworthy changes to be mentioned.
     ```
 
-4. Stage the modified / added / removed files which are to be committed.
+4. Stage the modified / added / removed files which are to be committed:
 
     ```sh
     git add --all

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "http2-server",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http2-server",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A simple, zero dependency, Node.js HTTP2 server for development projects.",
   "homepage": "https://github.com/tforster/http2-server#readme",
   "author": "Troy Forster <troy.forster@gmail.com> (https://www.tforster.com)",

--- a/src/HTTP2Server.js
+++ b/src/HTTP2Server.js
@@ -44,6 +44,7 @@ class HTTP2Server {
         ".js": "text/javascript",
         ".css": "text/css",
         ".json": "application/json",
+        ".xml": "application/xml",
 
         ".png": "image/png",
         ".jpg": "image/jpg",


### PR DESCRIPTION
The `application/xml` content type was added to the list of MIME types.  Fixes #3 